### PR TITLE
refactor: use single embedding model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "sgrep"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src/embedding/local.rs
+++ b/src/embedding/local.rs
@@ -291,15 +291,7 @@ impl BatchEmbedder for PooledEmbedder {
 #[cfg(not(test))]
 impl Default for PooledEmbedder {
     fn default() -> Self {
-        let cpu_count = std::thread::available_parallelism()
-            .map(|p| p.get())
-            .unwrap_or(4);
-        let default_pool = cpu_count.min(8);
-        let pool_size = env::var("SGREP_EMBEDDER_POOL_SIZE")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(default_pool);
-        Self::new(pool_size, DEFAULT_MAX_CACHE)
+        Self::new(1, DEFAULT_MAX_CACHE)
     }
 }
 


### PR DESCRIPTION
## Summary
Remove the 8-model pool and use a single embedding model. The pooled architecture was loading 8 ONNX models in parallel, but all models share a global ONNX thread pool (1-4 threads), causing internal contention rather than parallelism.

## Benefits
- ~8x faster startup time (loading 1 model instead of 8)
- ~8x less memory usage
- Same or better indexing performance (no internal ONNX contention)

## Changes
- Removed `SGREP_EMBEDDER_POOL_SIZE` env var configuration
- Simplified `PooledEmbedder::default()` to always use pool size 1