### PR TITLE
fix: configure NPM authentication in publish workflow

### DIFF
--- a/.github/workflows/publish-opencode.yml
+++ b/.github/workflows/publish-opencode.yml
@@ -62,8 +62,9 @@ jobs:
         working-directory: plugins/opencode
         run: bun install
 
+      - name: Configure NPM authentication
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
       - name: Publish to NPM
         working-directory: plugins/opencode
         run: bun publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Fixed `bun publish` authentication error by configuring NPM credentials in .npmrc file format instead of relying on environment variable.

## Details
The bun publish command reads authentication from the .npmrc configuration file, not from the NPM_TOKEN environment variable. This change creates the proper .npmrc configuration before publishing.

## Testing
The workflow will now authenticate properly when publishing new versions of the opencode plugin to NPM.