### PR TITLE
Add git worktree support to sgrep

### DIFF
--- a/default-ignore.txt
+++ b/default-ignore.txt
@@ -1,12 +1,8 @@
-# sgrep default ignore patterns
-# These patterns are always excluded from indexing
-
-# Version control
+.git
 .git/
 .hg/
 .svn/
 
-# Dependencies
 node_modules/
 vendor/
 target/
@@ -21,7 +17,6 @@ env/
 __pycache__/
 *.pyc
 
-# IDE and editors
 .idea/
 .vscode/
 .vs/
@@ -30,7 +25,6 @@ __pycache__/
 *~
 .DS_Store
 
-# Cache and temporary files
 .cache/
 .tmp/
 tmp/
@@ -38,14 +32,12 @@ temp/
 *.log
 *.tmp
 
-# Model and data directories
 .fastembed_cache/
 models/
 .models/
 data/
 .data/
 
-# Build artifacts
 *.o
 *.so
 *.dylib
@@ -57,7 +49,6 @@ data/
 *.jar
 *.war
 
-# Package manager locks (large files)
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
@@ -66,7 +57,6 @@ poetry.lock
 Pipfile.lock
 Gemfile.lock
 
-# Minified and generated files
 *.min.js
 *.min.css
 *.bundle.js

--- a/src/store/utils.rs
+++ b/src/store/utils.rs
@@ -1,8 +1,71 @@
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use blake3::Hasher;
 use directories::ProjectDirs;
+
+pub fn find_worktree_root(path: &Path) -> Option<PathBuf> {
+    let mut current = path.to_path_buf();
+
+    if current.is_file() {
+        current = current.parent()?.to_path_buf();
+    }
+
+    loop {
+        let git_path = current.join(".git");
+
+        if git_path.exists() {
+            return Some(current);
+        }
+
+        if !current.pop() {
+            break;
+        }
+    }
+
+    None
+}
+
+pub fn is_worktree(path: &Path) -> bool {
+    if let Some(root) = find_worktree_root(path) {
+        let git_path = root.join(".git");
+        git_path.is_file()
+    } else {
+        false
+    }
+}
+
+pub fn get_main_repo_path(worktree_path: &Path) -> Option<PathBuf> {
+    let root = find_worktree_root(worktree_path)?;
+    let git_file = root.join(".git");
+
+    if !git_file.is_file() {
+        return None;
+    }
+
+    let content = fs::read_to_string(&git_file).ok()?;
+    let gitdir_line = content.lines().next()?;
+
+    let gitdir = gitdir_line.strip_prefix("gitdir: ")?.trim();
+    let gitdir_path = PathBuf::from(gitdir);
+
+    let mut path = if gitdir_path.is_absolute() {
+        gitdir_path
+    } else {
+        git_file.parent()?.join(gitdir).canonicalize().ok()?
+    };
+
+    for _ in 0..3 {
+        path = path.parent()?.to_path_buf();
+    }
+
+    if path.join(".git").is_dir() {
+        Some(fs::canonicalize(&path).unwrap_or(path))
+    } else {
+        None
+    }
+}
 
 pub fn quantize_to_binary(vector: &[f32]) -> Vec<u64> {
     let num_words = vector.len().div_ceil(64);
@@ -40,6 +103,12 @@ pub fn hash_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
+    use uuid::Uuid;
+
+    fn temp_dir_with_name(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("sgrep_test_{}_{}", name, Uuid::new_v4()))
+    }
 
     #[test]
     fn hash_is_deterministic() {
@@ -67,5 +136,148 @@ mod tests {
     fn fallback_uses_home_directory() {
         let dir = fallback_data_dir();
         assert!(dir.to_string_lossy().contains(".sgrep"));
+    }
+
+    #[test]
+    fn find_worktree_root_finds_normal_repo() {
+        let temp_dir = temp_dir_with_name("git_root");
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .ok();
+
+        let nested = temp_dir.join("src").join("lib");
+        fs::create_dir_all(&nested).unwrap();
+
+        let result = find_worktree_root(&nested);
+        assert!(result.is_some());
+        let root = result.unwrap();
+        assert!(root.join(".git").exists());
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn find_worktree_root_returns_none_for_non_git() {
+        let temp_dir = temp_dir_with_name("not_git");
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let result = find_worktree_root(&temp_dir);
+        assert!(result.is_none());
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn is_worktree_returns_false_for_normal_repo() {
+        let temp_dir = temp_dir_with_name("normal_repo");
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .ok();
+
+        assert!(!is_worktree(&temp_dir));
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn get_main_repo_path_returns_none_for_normal_repo() {
+        let temp_dir = temp_dir_with_name("normal_repo2");
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .ok();
+
+        assert!(get_main_repo_path(&temp_dir).is_none());
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn worktree_functions_handle_actual_worktree() {
+        let main_repo = temp_dir_with_name("main_repo");
+        let worktree_dir = temp_dir_with_name("worktree");
+        fs::create_dir_all(&main_repo).unwrap();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&main_repo)
+            .output()
+            .ok();
+
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&main_repo)
+            .output()
+            .ok();
+
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&main_repo)
+            .output()
+            .ok();
+
+        fs::write(main_repo.join("test.txt"), "content").unwrap();
+
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&main_repo)
+            .output()
+            .ok();
+
+        Command::new("git")
+            .args(["commit", "-m", "Initial"])
+            .current_dir(&main_repo)
+            .output()
+            .ok();
+
+        let worktree_result = Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                worktree_dir.to_str().unwrap(),
+                "-b",
+                "test-branch",
+            ])
+            .current_dir(&main_repo)
+            .output();
+
+        if worktree_result.is_err() {
+            fs::remove_dir_all(&main_repo).ok();
+            return;
+        }
+
+        let git_file = worktree_dir.join(".git");
+        if !git_file.is_file() {
+            fs::remove_dir_all(&main_repo).ok();
+            fs::remove_dir_all(&worktree_dir).ok();
+            return;
+        }
+
+        assert!(is_worktree(&worktree_dir));
+
+        let main_path = get_main_repo_path(&worktree_dir);
+        assert!(main_path.is_some());
+        let main_canonical = fs::canonicalize(&main_repo).unwrap();
+        assert_eq!(main_path.unwrap(), main_canonical);
+
+        Command::new("git")
+            .args(["worktree", "remove", worktree_dir.to_str().unwrap()])
+            .current_dir(&main_repo)
+            .output()
+            .ok();
+
+        fs::remove_dir_all(&main_repo).ok();
+        fs::remove_dir_all(&worktree_dir).ok();
     }
 }


### PR DESCRIPTION
Enable sgrep to work with git worktrees. Each worktree gets its own separate index, but when a worktree is first initialized, it copies the index from the main repository as a starting point. This allows parallel usage across multiple worktrees without re-indexing from scratch, and each worktree can independently update its own index.