### PR TITLE
Fix Pinecone API camelCase serialization

### DIFF
--- a/src/remote/pinecone.rs
+++ b/src/remote/pinecone.rs
@@ -108,6 +108,7 @@ impl RemoteVectorStore for PineconeStore {
         }
 
         #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
         struct QueryRequest<'a> {
             vector: &'a [f32],
             top_k: usize,
@@ -182,6 +183,7 @@ impl RemoteVectorStore for PineconeStore {
     fn delete_namespace(&self) -> Result<()> {
         let url = self.vectors_url("vectors/delete");
         #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
         struct DeleteRequest<'a> {
             delete_all: bool,
             namespace: &'a str,


### PR DESCRIPTION
## Summary
Fixes the Pinecone delete operation failing with a 404 error due to incorrect JSON field name serialization.

The Pinecone REST API requires camelCase field names (deleteAll, topK, includeMetadata), but the code was using snake_case which Serde serialized as-is. Added #[serde(rename_all = "camelCase")] to DeleteRequest and QueryRequest structs to fix serialization for all affected operations.

## Changes
- Fixed DeleteRequest struct serialization (delete_all → deleteAll)
- Fixed QueryRequest struct serialization (top_k → topK, include_metadata → includeMetadata)

## Testing
The fix enables `sgrep index --force --remote` to complete the delete operation successfully.