### PR TITLE
Fix bun publish npm authentication

### DIFF
--- a/.github/workflows/publish-opencode.yml
+++ b/.github/workflows/publish-opencode.yml
@@ -63,8 +63,13 @@ jobs:
         run: bun install
 
       - name: Configure NPM authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        working-directory: plugins/opencode
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Publish to NPM
         working-directory: plugins/opencode
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 /indexes/
 /models/
 __pycache__/
+.npmrc


### PR DESCRIPTION
Configure npm authentication token in project directory and pass as environment variable to bun publish. This resolves the missing authentication error. Added .npmrc to .gitignore to prevent accidental secret commits.