### PR TITLE
Switch from bun publish to npm publish

### DIFF
--- a/.github/workflows/publish-opencode.yml
+++ b/.github/workflows/publish-opencode.yml
@@ -55,21 +55,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         working-directory: plugins/opencode
-        run: bun install
-
-      - name: Configure NPM authentication
-        working-directory: plugins/opencode
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        run: npm install
 
       - name: Publish to NPM
         working-directory: plugins/opencode
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --access public
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Summary
- Replace bun publish with npm publish for OpenCode plugin
- Use actions/setup-node@v4 with registry-url for proper npm authentication
- Fixes authentication errors that occurred with bun publish

## Test plan
- Merge PR and verify the publish workflow succeeds on version bump