### PR TITLE
Fix npm publish workflow and add manual trigger

### DIFF
--- a/.github/workflows/publish-opencode.yml
+++ b/.github/workflows/publish-opencode.yml
@@ -6,6 +6,7 @@ on:
       - 'plugins/opencode/package.json'
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   check-version:
@@ -24,20 +25,28 @@ jobs:
         run: |
           # Get current version from package.json
           CURRENT_VERSION=$(jq -r '.version // "0.0.0"' plugins/opencode/package.json)
-          
+
           # Exit if no version field exists
           if [ "$CURRENT_VERSION" = "0.0.0" ]; then
             echo "No version field found in package.json"
             echo "should-publish=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
+          # Always publish on manual trigger
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should-publish=true" >> $GITHUB_OUTPUT
+            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+            echo "Manual trigger, will publish $CURRENT_VERSION"
+            exit 0
+          fi
+
           # Get previous version from git
           PREVIOUS_VERSION=$(git show HEAD~1:plugins/opencode/package.json 2>/dev/null | jq -r '.version // "0.0.0"' || echo "0.0.0")
-          
+
           echo "Current version: $CURRENT_VERSION"
           echo "Previous version: $PREVIOUS_VERSION"
-          
+
           if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ] && [ -n "$CURRENT_VERSION" ]; then
             echo "should-publish=true" >> $GITHUB_OUTPUT
             echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Switch from bun publish to npm publish (fixes authentication issues)
- Use actions/setup-node@v4 with registry-url for proper npm auth
- Add workflow_dispatch for manual triggering to publish without version bump

## Test plan
- Merge PR and manually trigger workflow to publish v1.0.0